### PR TITLE
feat: output verification using custom tags

### DIFF
--- a/crates/cashu/src/nuts/mod.rs
+++ b/crates/cashu/src/nuts/mod.rs
@@ -70,3 +70,4 @@ pub use nut23::{
     MintQuoteBolt11Response, QuoteState as MintQuoteState,
 };
 pub use nut24::{MeltQuoteBolt12Request, MintQuoteBolt12Request, MintQuoteBolt12Response};
+pub use nutxx::{CairoWitness, Conditions as NutXXConditions};

--- a/crates/cashu/src/nuts/nut00/mod.rs
+++ b/crates/cashu/src/nuts/nut00/mod.rs
@@ -303,6 +303,12 @@ impl From<HTLCWitness> for Witness {
     }
 }
 
+impl From<CairoWitness> for Witness {
+    fn from(witness: CairoWitness) -> Self {
+        Self::CairoWitness(witness)
+    }
+}
+
 impl Witness {
     /// Add signatures to [`Witness`]
     pub fn add_signatures(&mut self, signatues: Vec<String>) {

--- a/crates/cashu/src/nuts/nut11/mod.rs
+++ b/crates/cashu/src/nuts/nut11/mod.rs
@@ -12,6 +12,7 @@ use bitcoin::secp256k1::schnorr::Signature;
 use serde::de::Error as DeserializerError;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use starknet_types_core::felt::Felt;
 use thiserror::Error;
 
 use super::nut00::Witness;
@@ -84,6 +85,9 @@ pub enum Error {
     /// Secret error
     #[error(transparent)]
     Secret(#[from] crate::secret::Error),
+    /// Felt from string error
+    #[error(transparent)]
+    FeltFromStr(<Felt as std::str::FromStr>::Err),
 }
 
 /// P2Pk Witness
@@ -316,8 +320,7 @@ pub enum SpendingConditions {
     /// Defined in [NUTXX](https://github.com/cashubtc/nuts/blob/main/xx.md)
     CairoConditions {
         /// Program hash
-        // data: Felt,
-        data: String, // Blake3Hash // TODO: maybe cleaner to use Felt ?
+        data: Felt,
         /// Additional Optional Spending [`NutXXConditions`]
         conditions: Option<NutXXConditions>,
     },
@@ -353,7 +356,7 @@ impl SpendingConditions {
     }
 
     /// New Cairo [SpendingConditions]
-    pub fn new_cairo(data: String, conditions: Option<NutXXConditions>) -> Self {
+    pub fn new_cairo(data: Felt, conditions: Option<NutXXConditions>) -> Self {
         Self::CairoConditions { data, conditions }
     }
 
@@ -414,7 +417,7 @@ impl SpendingConditions {
     }
 
     /// Cairo program output hash
-    pub fn output(&self) -> Option<String> {
+    pub fn output(&self) -> Option<Felt> {
         match self {
             Self::P2PKConditions { .. } => None,
             Self::HTLCConditions { .. } => None,
@@ -452,7 +455,8 @@ impl TryFrom<Nut10Secret> for SpendingConditions {
                     .and_then(|t| t.clone().try_into().ok()),
             }),
             Kind::Cairo => Ok(Self::CairoConditions {
-                data: secret.secret_data().data().to_string(),
+                data: Felt::from_str(secret.secret_data().data())
+                    .map_err(|e| Error::FeltFromStr(e))?,
                 conditions: secret
                     .secret_data()
                     .tags()

--- a/crates/cashu/src/nuts/nutxx/mod.rs
+++ b/crates/cashu/src/nuts/nutxx/mod.rs
@@ -34,14 +34,11 @@ pub enum Error {
     #[error(transparent)]
     CairoVerification(CairoVerificationError),
     /// Program hash verification error
-    #[error("Program hash from proof does not match program hash from secret")]
-    ProgramHashVerification,
+    #[error("Program hash ({0}) from proof does not match program hash ({1}) from secret")]
+    ProgramHashVerification(String, String),
     /// Output verification error
     #[error("Output hash from proof ({0}) does not match output hash from secret ({1})")]
     OutputHashVerification(String, String),
-    /// NUT11 Error
-    #[error(transparent)]
-    NUT11(#[from] super::nut11::Error),
     /// Serde Error
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
@@ -180,7 +177,10 @@ impl Proof {
         let program_hash = hash_many_pmv(program);
 
         if program_hash.to_string() != secret.secret_data().data() {
-            return Err(Error::ProgramHashVerification);
+            return Err(Error::ProgramHashVerification(
+                program_hash.to_string(),
+                secret.secret_data().data().to_string(),
+            ));
         }
 
         let conditions: Option<Conditions> = secret

--- a/crates/cashu/src/nuts/nutxx/mod.rs
+++ b/crates/cashu/src/nuts/nutxx/mod.rs
@@ -69,7 +69,7 @@ impl From<Conditions> for Vec<Vec<String>> {
         if let Some(output) = output {
             tags.push(vec![
                 TagKind::Custom("program_output".to_string()).to_string(),
-                output.to_hex_string(),
+                output.to_string(),
             ]);
         }
         tags
@@ -86,10 +86,10 @@ impl TryFrom<Vec<Vec<String>>> for Conditions {
                 continue;
             }
 
-            let tag_kind = TagKind::from(tag[0].as_str());
+            let tag_kind = TagKind::from(&tag[0]);
             match tag_kind {
                 TagKind::Custom(ref kind) if kind == "program_output" => {
-                    output = Some(Felt::from_hex(&tag[1]).unwrap());
+                    output = Some(Felt::from_str(&tag[1]).map_err(|e| Error::FeltFromStr(e))?);
                 }
                 _ => {}
             }

--- a/crates/cdk-cli/src/sub_commands/create_request.rs
+++ b/crates/cdk-cli/src/sub_commands/create_request.rs
@@ -35,6 +35,9 @@ pub struct CreateRequestSubCommand {
     /// HTLC: Preimage of the hash (to be used instead of hash)
     #[arg(long, conflicts_with = "hash")]
     preimage: Option<String>,
+    /// Cairo: Program and output hash
+    #[arg(long)]
+    cairo: Option<String>, // TODO: figure out what to put exactly here
     /// Transport type to use (nostr, http, or none)
     /// - nostr: Use Nostr transport and listen for payment
     /// - http: Use HTTP transport but only print the request
@@ -131,6 +134,7 @@ pub async fn create_request(
     // 2. Only HTLC condition with hash
     // 3. Only HTLC condition with preimage
     // 4. Both P2PK and HTLC conditions
+    // 5. // TODO: handle cases all cases above both with and without Cairo conditions
 
     let spending_conditions = if let Some(pubkey_strings) = &sub_command_args.pubkey {
         // Parse all pubkeys

--- a/crates/cdk-cli/src/sub_commands/receive.rs
+++ b/crates/cdk-cli/src/sub_commands/receive.rs
@@ -36,6 +36,7 @@ pub struct ReceiveSubCommand {
     /// Preimage
     #[arg(short, long,  action = clap::ArgAction::Append)]
     preimage: Vec<String>,
+    // TODO: add cairo proofs argument (path to json)
 }
 
 pub async fn receive(
@@ -155,6 +156,7 @@ async fn receive_token(
             ReceiveOptions {
                 p2pk_signing_keys: signing_keys.to_vec(),
                 preimages: preimage.to_vec(),
+                // TODO: add cairo_proofs here
                 ..Default::default()
             },
         )

--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -255,6 +255,9 @@ pub enum Error {
     /// Transaction not found
     #[error("Transaction not found")]
     TransactionNotFound,
+    /// Cairo proof not provided
+    #[error("Cairo proof not provided")]
+    CairoProofNotProvided,
     /// Custom Error
     #[error("`{0}`")]
     Custom(String),

--- a/crates/cdk/Cargo.toml
+++ b/crates/cdk/Cargo.toml
@@ -42,6 +42,9 @@ url.workspace = true
 utoipa = { workspace = true, optional = true }
 uuid.workspace = true
 jsonwebtoken = { workspace = true, optional = true }
+starknet-types-core = { workspace = true }
+cairo-air = { workspace = true }
+stwo_cairo_prover = { workspace = true }
 
 # -Z minimal-versions
 sync_wrapper = "0.1.2"

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -515,9 +515,7 @@ impl Wallet {
             SpendingConditions::CairoConditions {
                 data: _,
                 conditions: _,
-            } => {
-                (None, None, None, None) // TODO: implement
-            }
+            } => (None, None, None, None),
         };
 
         if refund_keys.is_some() && locktime.is_none() {

--- a/crates/cdk/src/wallet/receive.rs
+++ b/crates/cdk/src/wallet/receive.rs
@@ -14,7 +14,7 @@ use crate::amount::SplitTarget;
 use crate::dhke::construct_proofs;
 use crate::nuts::nut00::ProofsMethods;
 use crate::nuts::nut10::Kind;
-use crate::nuts::nutxx::hash_many_pmv;
+use crate::nuts::nutxx::hash_array_pmv;
 use crate::nuts::{Conditions, Proofs, PublicKey, SecretKey, SigFlag, State, Token};
 use crate::types::ProofInfo;
 use crate::util::hex;
@@ -71,7 +71,7 @@ impl Wallet {
                 let cairo_proof =
                     serde_json::from_str::<CairoProof<Blake2sMerkleHasher>>(p.as_str())?;
                 let program = &cairo_proof.claim.public_data.public_memory.program;
-                Ok::<(String, &String), Error>((hash_many_pmv(program).to_string(), p))
+                Ok::<(String, &String), Error>((hash_array_pmv(program).to_string(), p))
             })
             .collect::<Result<HashMap<String, &String>, _>>()?;
 

--- a/crates/cdk/src/wallet/receive.rs
+++ b/crates/cdk/src/wallet/receive.rs
@@ -4,14 +4,17 @@ use std::str::FromStr;
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
 use bitcoin::hashes::Hash;
 use bitcoin::XOnlyPublicKey;
+use cairo_air::CairoProof;
 use cdk_common::util::unix_time;
 use cdk_common::wallet::{Transaction, TransactionDirection};
+use stwo_cairo_prover::stwo_prover::core::vcs::blake2_merkle::Blake2sMerkleHasher;
 use tracing::instrument;
 
 use crate::amount::SplitTarget;
 use crate::dhke::construct_proofs;
 use crate::nuts::nut00::ProofsMethods;
 use crate::nuts::nut10::Kind;
+use crate::nuts::nutxx::hash_many_pmv;
 use crate::nuts::{Conditions, Proofs, PublicKey, SecretKey, SigFlag, State, Token};
 use crate::types::ProofInfo;
 use crate::util::hex;
@@ -60,6 +63,17 @@ impl Wallet {
                 Ok::<(String, &String), Error>((Sha256Hash::hash(&hex_bytes).to_string(), p))
             })
             .collect::<Result<HashMap<String, &String>, _>>()?;
+        // Map of program hash to cairo proof
+        let hashed_to_cairo_proof: HashMap<String, &String> = opts
+            .cairo_proofs
+            .iter()
+            .map(|p| {
+                let cairo_proof =
+                    serde_json::from_str::<CairoProof<Blake2sMerkleHasher>>(p.as_str())?;
+                let program = &cairo_proof.claim.public_data.public_memory.program;
+                Ok::<(String, &String), Error>((hash_many_pmv(program).to_string(), p))
+            })
+            .collect::<Result<HashMap<String, &String>, _>>()?;
 
         let p2pk_signing_keys: HashMap<XOnlyPublicKey, &SecretKey> = opts
             .p2pk_signing_keys
@@ -103,7 +117,11 @@ impl Wallet {
                             proof.add_preimage(preimage.to_string());
                         }
                         Kind::Cairo => {
-                            // TODO
+                            let hashed_program = secret.secret_data().data();
+                            let cairo_json_proof = hashed_to_cairo_proof
+                                .get(hashed_program)
+                                .ok_or(Error::CairoProofNotProvided)?;
+                            proof.add_cairo_proof(cairo_json_proof.to_string());
                         }
                     }
                     for pubkey in pubkeys {
@@ -283,6 +301,8 @@ pub struct ReceiveOptions {
     pub p2pk_signing_keys: Vec<SecretKey>,
     /// Preimages
     pub preimages: Vec<String>,
+    /// Cairo proofs
+    pub cairo_proofs: Vec<String>,
     /// Metadata
     pub metadata: HashMap<String, String>,
 }


### PR DESCRIPTION
To consider: maybe what we call output in the tags should be renamed output_hash and we could add another tag output of type Vec<Vec<Felt>> that encodes the output directly (would be [0x1] in the test example) and users could choose one or another depending on use cases.