### PR TITLE
M3 & M4: Cairo cdk-cli & NUTXX Mint Info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,8 @@ starknet-types-core = "0.1.9"
 cairo-air = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "62c3c4a" }
 stwo_cairo_prover = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "62c3c4a" }
 cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo.git", rev = "5cc466a" }
+cairo-prove = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "335de15"}
+
 
 
 [workspace.metadata]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ rustls = { version = "0.23.28", default-features = false, features = ["ring"] }
 starknet-types-core = "0.1.9"
 cairo-air = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "62c3c4a" }
 stwo_cairo_prover = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "62c3c4a" }
-
+cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo.git", rev = "5cc466a" }
 
 
 [workspace.metadata]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,8 +105,7 @@ cairo-air = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "62c3c
 stwo_cairo_prover = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "62c3c4a" }
 cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo.git", rev = "5cc466a" }
 cairo-prove = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "335de15"}
-
-
+cairo-lang-executable = { git = "https://github.com/starkware-libs/cairo.git", rev = "5cc466a" }
 
 [workspace.metadata]
 authors = ["CDK Developers"]

--- a/crates/cashu/Cargo.toml
+++ b/crates/cashu/Cargo.toml
@@ -38,6 +38,7 @@ strum = { workspace = true, optional = true }
 strum_macros = { workspace = true, optional = true }
 cairo-air = { workspace = true }
 stwo_cairo_prover = { workspace = true }
+starknet-types-core = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { workspace = true, features = ["wasm-bindgen", "inaccurate"] }

--- a/crates/cashu/Cargo.toml
+++ b/crates/cashu/Cargo.toml
@@ -38,7 +38,6 @@ strum = { workspace = true, optional = true }
 strum_macros = { workspace = true, optional = true }
 cairo-air = { workspace = true }
 stwo_cairo_prover = { workspace = true }
-starknet-types-core = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { workspace = true, features = ["wasm-bindgen", "inaccurate"] }

--- a/crates/cashu/src/nuts/nut06.rs
+++ b/crates/cashu/src/nuts/nut06.rs
@@ -337,7 +337,7 @@ pub struct Nuts {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "auth")]
     pub nut22: Option<BlindAuthSettings>,
-    // NUTXX Settings
+    /// NUTXX Settings
     #[serde(default)]
     #[serde(rename = "xx")]
     pub nutxx: NutXXSettings,

--- a/crates/cashu/src/nuts/nut06.rs
+++ b/crates/cashu/src/nuts/nut06.rs
@@ -337,7 +337,7 @@ pub struct Nuts {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "auth")]
     pub nut22: Option<BlindAuthSettings>,
-    // NUTXX Settings
+    /// NUTXX Settings
     #[serde(default)]
     #[serde(rename = "xx")]
     pub nutxx: NutXXSettings,
@@ -462,7 +462,7 @@ impl Nuts {
     pub fn nutxx(self, supported: bool) -> Self {
         Self {
             nutxx: NutXXSettings {
-                supported: supported,
+                supported,
                 ..NutXXSettings::default()
             },
             ..self

--- a/crates/cashu/src/nuts/nut06.rs
+++ b/crates/cashu/src/nuts/nut06.rs
@@ -459,7 +459,7 @@ impl Nuts {
     }
 
     /// NutXX settings
-    pub fn nutxx(mut self, supported: bool) -> Self {
+    pub fn nutxx(self, supported: bool) -> Self {
         Self {
             nutxx: NutXXSettings {
                 supported: supported,

--- a/crates/cashu/src/nuts/nut06.rs
+++ b/crates/cashu/src/nuts/nut06.rs
@@ -14,6 +14,7 @@ use super::nut19::CachedEndpoint;
 use super::{nut04, nut05, nut15, nut19, MppMethodSettings};
 #[cfg(feature = "auth")]
 use super::{AuthRequired, BlindAuthSettings, ClearAuthSettings, ProtectedEndpoint};
+use crate::nutxx::NutXXSettings;
 use crate::CurrencyUnit;
 
 /// Mint Version
@@ -336,6 +337,10 @@ pub struct Nuts {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "auth")]
     pub nut22: Option<BlindAuthSettings>,
+    // NUTXX Settings
+    #[serde(default)]
+    #[serde(rename = "xx")]
+    pub nutxx: NutXXSettings,
 }
 
 impl Nuts {
@@ -449,6 +454,17 @@ impl Nuts {
     pub fn nut20(self, supported: bool) -> Self {
         Self {
             nut20: SupportedSettings { supported },
+            ..self
+        }
+    }
+
+    /// NutXX settings
+    pub fn nutxx(mut self, supported: bool) -> Self {
+        Self {
+            nutxx: NutXXSettings {
+                supported: supported,
+                ..NutXXSettings::default()
+            },
             ..self
         }
     }

--- a/crates/cashu/src/nuts/nut06.rs
+++ b/crates/cashu/src/nuts/nut06.rs
@@ -337,7 +337,7 @@ pub struct Nuts {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "auth")]
     pub nut22: Option<BlindAuthSettings>,
-    /// NUTXX Settings
+    // NUTXX Settings
     #[serde(default)]
     #[serde(rename = "xx")]
     pub nutxx: NutXXSettings,

--- a/crates/cashu/src/nuts/nutxx/mod.rs
+++ b/crates/cashu/src/nuts/nutxx/mod.rs
@@ -57,6 +57,62 @@ pub enum Error {
     NotImplemented,
 }
 
+/// Mint Info CairoProverConfig field
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CairoProverConfig {
+    pub version: String,
+    pub merkle_hasher: String,
+}
+/// Mint Info optional features bootloader field
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BootloaderFeature {
+    pub supported: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+}
+/// Mint Info optional features
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub struct NutXXOptionalFeatures {
+    pub bootloader: BootloaderFeature,
+}
+impl Default for BootloaderFeature {
+    /// Default bootloader feature is unsupported with no version or hash
+    fn default() -> Self {
+        Self {
+            supported: false,
+            version: None,
+            hash: None,
+        }
+    }
+}
+
+/// Mint Info NUT-XX settings
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NutXXSettings {
+    pub supported: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optional_features: Option<NutXXOptionalFeatures>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cairo_prover_config: Option<CairoProverConfig>,
+}
+
+impl Default for NutXXSettings {
+    /// Default NUT-XX settings
+    fn default() -> Self {
+        Self {
+            // NUT-XX advertised by default unless explicitly disabled in config
+            supported: true,
+            // Show bootloader as present but disabled by default
+            optional_features: Some(NutXXOptionalFeatures {
+                bootloader: BootloaderFeature::default(),
+            }),
+            cairo_prover_config: None,
+        }
+    }
+}
+
 /// Cairo Executable
 #[derive(Deserialize)]
 pub struct Executable {

--- a/crates/cashu/src/nuts/nutxx/mod.rs
+++ b/crates/cashu/src/nuts/nutxx/mod.rs
@@ -58,20 +58,27 @@ pub enum Error {
 /// Mint Info CairoProverConfig field
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CairoProverConfig {
+    /// Cairo Prover version
     pub version: String,
 }
+
 /// Mint Info optional features bootloader field
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BootloaderFeature {
+    /// Is bootloader supported
     pub supported: bool,
+    /// Bootloader version
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// Boastloader hash
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hash: Option<String>,
 }
+
 /// Mint Info optional features
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub struct NutXXOptionalFeatures {
+    /// Bootloader feature
     pub bootloader: BootloaderFeature,
 }
 impl Default for BootloaderFeature {
@@ -88,9 +95,12 @@ impl Default for BootloaderFeature {
 /// Mint Info NUT-XX settings
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NutXXSettings {
+    /// Is NUT-XX supported
     pub supported: bool,
+    /// Optional features
     #[serde(skip_serializing_if = "Option::is_none")]
     pub optional_features: Option<NutXXOptionalFeatures>,
+    /// Cairo Prover configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cairo_prover_config: Option<CairoProverConfig>,
 }
@@ -286,17 +296,17 @@ mod tests {
 
     /// Cairo Executable
     #[derive(Deserialize)]
-    pub struct Executable {
+    struct Executable {
         /// Cairo program
-        pub program: Program,
+        program: Program,
     }
 
     /// Cairo Program
     #[derive(Deserialize)]
-    pub struct Program {
+    struct Program {
         #[serde(deserialize_with = "deserialize_felt_vec")]
         /// Cairo program bytecode
-        pub bytecode: Vec<Felt>,
+        bytecode: Vec<Felt>,
     }
 
     fn deserialize_felt_vec<'de, D>(deserializer: D) -> Result<Vec<Felt>, D::Error>
@@ -324,7 +334,7 @@ mod tests {
     }
 
     /// Hash an array of Felts in little endian format using Blake2s
-    pub fn hash_array_felt(bytecode: &[Felt]) -> [u8; 32] {
+    fn hash_array_felt(bytecode: &[Felt]) -> [u8; 32] {
         let mut hasher = Blake2sHasher::default();
         for felt in bytecode {
             for byte in felt.to_bytes_le().iter() {

--- a/crates/cashu/src/nuts/nutxx/mod.rs
+++ b/crates/cashu/src/nuts/nutxx/mod.rs
@@ -57,15 +57,19 @@ pub enum Error {
     NotImplemented,
 }
 
+/// Cairo Executable
 #[derive(Deserialize)]
 pub struct Executable {
-    program: Program,
+    /// Cairo program
+    pub program: Program,
 }
 
+/// Cairo Program
 #[derive(Deserialize)]
 pub struct Program {
     #[serde(deserialize_with = "deserialize_felt_vec")]
-    bytecode: Vec<Felt>,
+    /// Cairo program bytecode
+    pub bytecode: Vec<Felt>,
 }
 
 fn deserialize_felt_vec<'de, D>(deserializer: D) -> Result<Vec<Felt>, D::Error>
@@ -90,6 +94,17 @@ where
             Ok(corrected_felt)
         })
         .collect()
+}
+
+/// Hash an array of Felts in little endian format using Blake2s
+pub fn hash_array_felt(bytecode: &[Felt]) -> [u8; 32] {
+    let mut hasher = Blake2sHasher::default();
+    for felt in bytecode {
+        for byte in felt.to_bytes_le().iter() {
+            hasher.update(&[*byte]);
+        }
+    }
+    hasher.finalize().into()
 }
 
 /// Cairo spending conditions
@@ -262,16 +277,6 @@ mod tests {
     use super::*;
     use crate::secret::Secret;
     use crate::{Amount, Id, Kind, Nut10Secret, SecretKey};
-
-    fn hash_array_felt(bytecode: &[Felt]) -> [u8; 32] {
-        let mut hasher = Blake2sHasher::default();
-        for felt in bytecode {
-            for byte in felt.to_bytes_le().iter() {
-                hasher.update(&[*byte]);
-            }
-        }
-        hasher.finalize().into()
-    }
 
     #[test]
     fn test_verify() {

--- a/crates/cashu/src/nuts/nutxx/mod.rs
+++ b/crates/cashu/src/nuts/nutxx/mod.rs
@@ -126,25 +126,11 @@ pub struct Conditions {
     /// Blake2s hash of the output of the program
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output: Option<[u8; 32]>,
-    /// The preprocessed trace variant to use
-    ///
-    /// Default is `false` (CanonicalWithoutPedersen)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub with_pedersen: Option<bool>,
-    /// Whether the proof requires a bootloader
-    ///
-    /// Default is `false`
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub with_bootloader: Option<bool>,
 }
 
 impl From<Conditions> for Vec<Vec<String>> {
     fn from(conditions: Conditions) -> Vec<Vec<String>> {
-        let Conditions {
-            output,
-            with_pedersen,
-            with_bootloader,
-        } = conditions;
+        let Conditions { output } = conditions;
 
         let mut tags = Vec::new();
 
@@ -152,18 +138,6 @@ impl From<Conditions> for Vec<Vec<String>> {
             tags.push(vec![
                 TagKind::Custom("program_output".to_string()).to_string(),
                 hex::encode(output),
-            ]);
-        }
-        if let Some(with_pedersen) = with_pedersen {
-            tags.push(vec![
-                TagKind::Custom("with_pedersen".to_string()).to_string(),
-                with_pedersen.to_string(),
-            ]);
-        }
-        if let Some(with_bootloader) = with_bootloader {
-            tags.push(vec![
-                TagKind::Custom("with_bootloader".to_string()).to_string(),
-                with_bootloader.to_string(),
             ]);
         }
         tags
@@ -174,8 +148,6 @@ impl TryFrom<Vec<Vec<String>>> for Conditions {
     type Error = Error;
     fn try_from(tags: Vec<Vec<String>>) -> Result<Conditions, Self::Error> {
         let mut output = None;
-        let mut with_pedersen = None;
-        let mut with_bootloader = None;
 
         for tag in tags {
             if tag.len() < 2 {
@@ -187,21 +159,11 @@ impl TryFrom<Vec<Vec<String>>> for Conditions {
                 TagKind::Custom(ref kind) if kind == "program_output" => {
                     output = Some(hex::decode(&tag[1])?.as_slice().try_into()?);
                 }
-                TagKind::Custom(ref kind) if kind == "with_pedersen" => {
-                    with_pedersen = Some(&tag[1] == "true");
-                }
-                TagKind::Custom(ref kind) if kind == "with_bootloader" => {
-                    with_bootloader = Some(&tag[1] == "true");
-                }
                 _ => {}
             }
         }
 
-        Ok(Conditions {
-            output,
-            with_pedersen,
-            with_bootloader,
-        })
+        Ok(Conditions { output })
     }
 }
 
@@ -285,39 +247,23 @@ impl Proof {
             ));
         }
 
-        let mut preprocessed_trace = PreProcessedTraceVariant::CanonicalWithoutPedersen;
-
         let conditions: Option<Conditions> = secret
             .secret_data()
             .tags()
             .and_then(|c| c.clone().try_into().ok());
-        if let Some(conditions) = conditions {
-            if let Some(output_condition) = conditions.output {
-                // check if the output in the claim matches the output in the conditions
-                let output = hash_array_pmv(&cairo_proof.claim.public_data.public_memory.output);
-                if output != output_condition {
-                    return Err(Error::OutputHashVerification(
-                        hex::encode(output),
-                        hex::encode(output_condition),
-                    ));
-                }
-            }
 
-            if let Some(with_pedersen) = conditions.with_pedersen {
-                preprocessed_trace = match with_pedersen {
-                    true => PreProcessedTraceVariant::Canonical,
-                    false => PreProcessedTraceVariant::CanonicalWithoutPedersen,
-                };
-            }
-
-            if let Some(with_bootloader) = conditions.with_bootloader {
-                // TODO: Bootloader support not yet implemented.
-                if with_bootloader {
-                    return Err(Error::NotImplemented);
-                }
+        if let Some(output_condition) = conditions.and_then(|c| c.output) {
+            // check if the output in the claim matches the output in the conditions
+            let output = hash_array_pmv(&cairo_proof.claim.public_data.public_memory.output);
+            if output != output_condition {
+                return Err(Error::OutputHashVerification(
+                    hex::encode(output),
+                    hex::encode(output_condition),
+                ));
             }
         }
 
+        let preprocessed_trace = PreProcessedTraceVariant::CanonicalWithoutPedersen; // TODO: give option
         let result = verify_cairo::<Blake2sMerkleChannel>(
             cairo_proof,
             secure_pcs_config(),
@@ -416,13 +362,9 @@ mod tests {
 
         let cond_false = Conditions {
             output: Some(output_false),
-            with_pedersen: Some(false),
-            with_bootloader: Some(false),
         };
         let cond_true = Conditions {
             output: Some(output_true),
-            with_pedersen: Some(false),
-            with_bootloader: Some(false),
         };
 
         let secret_is_prime_true: Secret =
@@ -471,60 +413,11 @@ mod tests {
     #[test]
     fn test_secret_ser() {
         // Testing the serde serialization of the secret
-        let conditions = Conditions {
-            output: None,
-            with_pedersen: Some(true),
-            with_bootloader: None,
-        };
+        let conditions = Conditions { output: None };
         let data = Blake2sHasher::hash(b"1234567890abcdef").to_string();
         let secret = Nut10Secret::new(Kind::Cairo, data, Some(conditions));
         let secret_str = serde_json::to_string(&secret).unwrap();
         let secret_der: Nut10Secret = serde_json::from_str(&secret_str).unwrap();
         assert_eq!(secret, secret_der);
-    }
-
-    #[test]
-    fn test_verify_with_bootloader_not_implemented() {
-        use super::Error;
-        let secret_key =
-            SecretKey::from_str("99590802251e78ee1051648439eedb003dc539093a48a44e7b8f2642c909ea37")
-                .unwrap();
-        let v_key = secret_key.public_key();
-
-        let executable_json = include_str!("./test/is_prime_executable.json");
-        let executable: Executable = serde_json::from_str(executable_json).unwrap();
-        let program_hash = hash_array_felt(&executable.program.bytecode);
-        let output_true = hash_array_felt(&[Felt::from(1)]);
-
-        let cond_bootloader = Conditions {
-            output: Some(output_true),
-            with_pedersen: Some(true),
-            with_bootloader: Some(true),
-        };
-
-        let secret_is_prime_true: Secret = Nut10Secret::new(
-            Kind::Cairo,
-            hex::encode(program_hash),
-            Some(cond_bootloader),
-        )
-        .try_into()
-        .unwrap();
-
-        let cairo_proof_is_prime_7 = include_str!("./test/is_prime_proof_7.json").to_string();
-        let witness_is_prime_7 = CairoWitness {
-            cairo_proof_json: cairo_proof_is_prime_7,
-        };
-
-        let proof: Proof = Proof {
-            amount: Amount::ZERO,
-            keyset_id: Id::from_str("009a1f293253e41e").unwrap(),
-            secret: secret_is_prime_true,
-            c: v_key,
-            witness: Some(Witness::CairoWitness(witness_is_prime_7)),
-            dleq: None,
-        };
-
-        let result = proof.verify_cairo();
-        assert!(matches!(result, Err(Error::NotImplemented)));
     }
 }

--- a/crates/cdk-axum/src/lib.rs
+++ b/crates/cdk-axum/src/lib.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use anyhow::Result;
 #[cfg(feature = "auth")]
 use auth::create_auth_router;
+use axum::extract::DefaultBodyLimit;
 use axum::middleware::from_fn;
 use axum::response::Response;
 use axum::routing::{get, post};
@@ -204,7 +205,10 @@ pub async fn create_mint_router_with_custom_cache(
         .route("/keys", get(get_keys))
         .route("/keysets", get(get_keysets))
         .route("/keys/{keyset_id}", get(get_keyset_pubkeys))
-        .route("/swap", post(cache_post_swap))
+        .route(
+            "/swap",
+            post(cache_post_swap).layer(DefaultBodyLimit::max(64 * 1024 * 1024)),
+        )
         .route("/mint/quote/bolt11", post(post_mint_bolt11_quote))
         .route(
             "/mint/quote/bolt11/{quote_id}",

--- a/crates/cdk-cli/Cargo.toml
+++ b/crates/cdk-cli/Cargo.toml
@@ -21,7 +21,11 @@ redb = ["dep:cdk-redb"]
 anyhow.workspace = true
 bip39.workspace = true
 bitcoin.workspace = true
-cdk = { workspace = true, default-features = false, features = ["wallet", "auth"]}
+cashu = { workspace = true }
+cdk = { workspace = true, default-features = false, features = [
+    "wallet",
+    "auth",
+] }
 cdk-redb = { workspace = true, features = ["wallet"], optional = true }
 cdk-sqlite = { workspace = true, features = ["wallet"] }
 clap.workspace = true
@@ -34,10 +38,13 @@ home.workspace = true
 nostr-sdk = { version = "0.41.0", default-features = false, features = [
     "nip04",
     "nip44",
-    "nip59"
-]}
+    "nip59",
+] }
 reqwest.workspace = true
 url.workspace = true
 serde_with.workspace = true
 lightning.workspace = true
 trust-dns-resolver = { version = "0.23.2", optional = true }
+stwo_cairo_prover = { workspace = true }
+cairo-lang-runner = { workspace = true }
+starknet-types-core = { workspace = true }

--- a/crates/cdk-cli/Cargo.toml
+++ b/crates/cdk-cli/Cargo.toml
@@ -48,3 +48,5 @@ trust-dns-resolver = { version = "0.23.2", optional = true }
 stwo_cairo_prover = { workspace = true }
 cairo-lang-runner = { workspace = true }
 starknet-types-core = { workspace = true }
+cairo-prove = { workspace = true }
+

--- a/crates/cdk-cli/Cargo.toml
+++ b/crates/cdk-cli/Cargo.toml
@@ -49,4 +49,4 @@ stwo_cairo_prover = { workspace = true }
 cairo-lang-runner = { workspace = true }
 starknet-types-core = { workspace = true }
 cairo-prove = { workspace = true }
-
+cairo-lang-executable = { workspace = true }

--- a/crates/cdk-cli/src/sub_commands/receive.rs
+++ b/crates/cdk-cli/src/sub_commands/receive.rs
@@ -42,7 +42,7 @@ pub struct ReceiveSubCommand {
     /// Preimage
     #[arg(short, long,  action = clap::ArgAction::Append)]
     preimage: Vec<String>,
-    /// Generate proof from Cairo executable
+    /// Generate witness from Cairo executable
     /// <cairo_executable> <n_inputs> <input1> <input2> ...
     #[arg(long, action = clap::ArgAction::Append, num_args = 1.., value_terminator = "--")]
     cairo: Vec<String>,
@@ -57,7 +57,7 @@ fn cairo_prove(executable_path: &Path, args: Vec<String>) -> String {
     let args: Vec<Arg> = args
         .iter()
         .map(|a| {
-            Felt::from_hex(a)
+            Felt::from_dec_str(a)
                 .expect("Invalid argument for Cairo proof")
                 .into()
         })
@@ -133,7 +133,7 @@ pub async fn receive(
         }
         let mut input_args = Vec::new();
         for arg in &cairo_args[2..2 + n_inputs] {
-            if Felt::from_hex(arg).is_err() {
+            if Felt::from_dec_str(arg).is_err() {
                 return Err(anyhow!("Could not parse program input: {} as a Felt", arg));
             }
             input_args.push(arg.clone());

--- a/crates/cdk-cli/src/sub_commands/receive.rs
+++ b/crates/cdk-cli/src/sub_commands/receive.rs
@@ -81,7 +81,7 @@ fn cairo_prove(executable_path: &Path, args: Vec<String>) -> String {
         "[cairo_prove fn] Cairo proof generated successfully in {} ms",
         start.elapsed().as_millis()
     );
-    serde_json::to_string(&cairo_proof).unwrap(); // returns a json serialized CairoProof
+    serde_json::to_string(&cairo_proof).unwrap() // returns a json serialized CairoProof
 }
 
 pub async fn receive(

--- a/crates/cdk-cli/src/sub_commands/receive.rs
+++ b/crates/cdk-cli/src/sub_commands/receive.rs
@@ -1,9 +1,12 @@
 use std::collections::HashSet;
 use std::path::Path;
 use std::str::FromStr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
+use cairo_lang_runner::Arg;
+use cairo_prove::execute::execute;
+use cairo_prove::prove::{prove, prover_input_from_runner};
 use cdk::nuts::{SecretKey, Token};
 use cdk::util::unix_time;
 use cdk::wallet::multi_mint_wallet::MultiMintWallet;
@@ -13,6 +16,9 @@ use cdk::Amount;
 use clap::Args;
 use nostr_sdk::nips::nip04;
 use nostr_sdk::{Filter, Keys, Kind, Timestamp};
+use starknet_types_core::felt::Felt;
+use stwo_cairo_prover::stwo_prover::core::fri::FriConfig;
+use stwo_cairo_prover::stwo_prover::core::pcs::PcsConfig;
 
 use crate::nostr_storage;
 use crate::utils::get_or_create_wallet;
@@ -36,7 +42,46 @@ pub struct ReceiveSubCommand {
     /// Preimage
     #[arg(short, long,  action = clap::ArgAction::Append)]
     preimage: Vec<String>,
-    // TODO: add cairo proofs argument (path to json)
+    /// Generate proof from Cairo executable
+    /// <cairo_executable> <n_inputs> <input1> <input2> ...
+    #[arg(long, action = clap::ArgAction::Append, num_args = 1.., value_terminator = "--")]
+    cairo: Vec<String>,
+}
+
+fn cairo_prove(executable_path: &Path, args: Vec<String>) -> String {
+    let executable = serde_json::from_reader(
+        std::fs::File::open(executable_path).expect("Failed to open Cairo executable file"),
+    )
+    .expect("Failed to parse Cairo executable JSON");
+
+    let args: Vec<Arg> = args
+        .iter()
+        .map(|a| {
+            Felt::from_hex(a)
+                .expect("Invalid argument for Cairo proof")
+                .into()
+        })
+        .collect();
+
+    let runner = execute(executable, args);
+    let prover_input = prover_input_from_runner(&runner);
+
+    let pcs_config = PcsConfig {
+        pow_bits: 26,
+        fri_config: FriConfig {
+            log_last_layer_degree_bound: 0,
+            log_blowup_factor: 1,
+            n_queries: 70,
+        },
+    };
+
+    let start = Instant::now();
+    let cairo_proof = prove(prover_input, pcs_config);
+    println!(
+        "[cairo_prove fn] Cairo proof generated successfully in {} ms",
+        start.elapsed().as_millis()
+    );
+    return serde_json::to_string(&cairo_proof).unwrap(); // returns a json serialized CairoProof
 }
 
 pub async fn receive(
@@ -63,6 +108,40 @@ pub async fn receive(
         signing_keys.append(&mut s_keys);
     }
 
+    let mut cairo_proofs_json: Vec<String> = Vec::new();
+    if !sub_command_args.cairo.is_empty() {
+        let cairo_args = &sub_command_args.cairo;
+        if cairo_args.len() < 2 {
+            return Err(anyhow!(
+                "Cairo arguments must include at least the executable path and number of inputs"
+            ));
+        }
+        let exec_path = Path::new(&cairo_args[0]);
+        if !exec_path.exists() {
+            return Err(anyhow!(
+                "Cairo executable file note found: {}",
+                exec_path.display()
+            ));
+        }
+        let n_inputs: usize = cairo_args[1]
+            .parse::<usize>()
+            .map_err(|_| anyhow!("Invalid number of inputs"))?;
+        if cairo_args.len() != 2 + n_inputs {
+            return Err(anyhow!(
+                "Given number of Cairo input arguments does not match the specified number of inputs"
+            ));
+        }
+        let mut input_args = Vec::new();
+        for arg in &cairo_args[2..2 + n_inputs] {
+            if Felt::from_hex(arg).is_err() {
+                return Err(anyhow!("Could not parse program input: {} as a Felt", arg));
+            }
+            input_args.push(arg.clone());
+        }
+
+        cairo_proofs_json.push(cairo_prove(exec_path, input_args));
+    }
+
     let amount = match &sub_command_args.token {
         Some(token_str) => {
             receive_token(
@@ -70,6 +149,7 @@ pub async fn receive(
                 token_str,
                 &signing_keys,
                 &sub_command_args.preimage,
+                &cairo_proofs_json,
             )
             .await?
         }
@@ -110,6 +190,7 @@ pub async fn receive(
                     token_str,
                     &signing_keys,
                     &sub_command_args.preimage,
+                    &cairo_proofs_json,
                 )
                 .await
                 {
@@ -136,6 +217,7 @@ async fn receive_token(
     token_str: &str,
     signing_keys: &[SecretKey],
     preimage: &[String],
+    cairo_proofs_json: &[String],
 ) -> Result<Amount> {
     let token: Token = Token::from_str(token_str)?;
 
@@ -156,7 +238,7 @@ async fn receive_token(
             ReceiveOptions {
                 p2pk_signing_keys: signing_keys.to_vec(),
                 preimages: preimage.to_vec(),
-                // TODO: add cairo_proofs here
+                cairo_proofs: cairo_proofs_json.to_vec(),
                 ..Default::default()
             },
         )

--- a/crates/cdk-cli/src/sub_commands/receive.rs
+++ b/crates/cdk-cli/src/sub_commands/receive.rs
@@ -81,7 +81,7 @@ fn cairo_prove(executable_path: &Path, args: Vec<String>) -> String {
         "[cairo_prove fn] Cairo proof generated successfully in {} ms",
         start.elapsed().as_millis()
     );
-    return serde_json::to_string(&cairo_proof).unwrap(); // returns a json serialized CairoProof
+    serde_json::to_string(&cairo_proof).unwrap(); // returns a json serialized CairoProof
 }
 
 pub async fn receive(

--- a/crates/cdk-cli/src/sub_commands/send.rs
+++ b/crates/cdk-cli/src/sub_commands/send.rs
@@ -36,13 +36,11 @@ pub struct SendSubCommand {
     /// Pubkey to lock proofs to
     #[arg(short, long, action = clap::ArgAction::Append)]
     pubkey: Vec<String>,
-    // Cairo executable required to generate proofs
-    // <cairo_executable> n_args <arg1> <arg2> ...
-    #[arg(long, conflicts_with = "cairo_program_hash")]
+    // Cairo executable required to generate proofs, and accepted program outputs <cairo_executable> n_outputs <output1> <output2> ...
+    #[arg(long, action = clap::ArgAction::Append, num_args = 1.., conflicts_with = "cairo_program_hash")]
     cairo_executable: Option<Vec<String>>,
-    // Alternative to cairo executable, the hash of the cairo program
-    // <program_hash> n_args <arg1> <arg2> ...
-    #[arg(long, conflicts_with = "cairo_executable")]
+    // Alternative to cairo executable, the hash of the cairo program: --cairo_program_hash <program_hash (hex format)> n_output <output1> <output2> ...
+    #[arg(long, action = clap::ArgAction::Append, num_args = 1.., conflicts_with = "cairo_executable")]
     cairo_program_hash: Option<Vec<String>>,
     /// Refund keys that can be used after locktime
     #[arg(long, action = clap::ArgAction::Append)]

--- a/crates/cdk-cli/src/sub_commands/send.rs
+++ b/crates/cdk-cli/src/sub_commands/send.rs
@@ -11,7 +11,6 @@ use cdk::wallet::{MultiMintWallet, SendMemo, SendOptions};
 use cdk::Amount;
 use clap::Args;
 use starknet_types_core::felt::Felt;
-use stwo_cairo_prover::witness::prelude::Felt252;
 
 use crate::sub_commands::balance::mint_balances;
 use crate::utils::{

--- a/crates/cdk-cli/src/sub_commands/send.rs
+++ b/crates/cdk-cli/src/sub_commands/send.rs
@@ -225,6 +225,8 @@ pub async fn send(
 
             let output_condition = Some(NutXXConditions {
                 output: Some(hashed_output_conditions),
+                with_pedersen: None,   // TODO: add option as argument in CLI
+                with_bootloader: None, // Currently unsupported by the wallet
             });
 
             Some(SpendingConditions::CairoConditions {
@@ -302,6 +304,8 @@ pub async fn send(
                     // TODO: support multiple outputs
                     let output_condition = Some(NutXXConditions {
                         output: Some(hashed_output_conditions),
+                        with_pedersen: None, // TODO: add option as argument in CLI
+                        with_bootloader: None, // Currently unsupported by the wallet
                     });
 
                     Some(SpendingConditions::CairoConditions {

--- a/crates/cdk-cli/src/sub_commands/send.rs
+++ b/crates/cdk-cli/src/sub_commands/send.rs
@@ -225,8 +225,6 @@ pub async fn send(
 
             let output_condition = Some(NutXXConditions {
                 output: Some(hashed_output_conditions),
-                with_pedersen: None,   // TODO: add option as argument in CLI
-                with_bootloader: None, // Currently unsupported by the wallet
             });
 
             Some(SpendingConditions::CairoConditions {
@@ -304,8 +302,6 @@ pub async fn send(
                     // TODO: support multiple outputs
                     let output_condition = Some(NutXXConditions {
                         output: Some(hashed_output_conditions),
-                        with_pedersen: None, // TODO: add option as argument in CLI
-                        with_bootloader: None, // Currently unsupported by the wallet
                     });
 
                     Some(SpendingConditions::CairoConditions {

--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -255,9 +255,9 @@ pub enum Error {
     /// Transaction not found
     #[error("Transaction not found")]
     TransactionNotFound,
-    /// Cairo proof not provided
-    #[error("Cairo proof not provided")]
-    CairoProofNotProvided,
+    /// Cairo witness not provided
+    #[error("Cairo witness not provided")]
+    CairoWitnessNotProvided,
     /// Custom Error
     #[error("`{0}`")]
     Custom(String),

--- a/crates/cdk-integration-tests/tests/cairo-cli.rs
+++ b/crates/cdk-integration-tests/tests/cairo-cli.rs
@@ -1,0 +1,49 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[test]
+fn cairo_cli_flow_script_succeeds() {
+    // Paths
+    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")); // crates/cdk-integration-tests
+    let script_path = crate_dir.join("tests/scripts/cairo-cli-test-flow.sh");
+    assert!(
+        script_path.exists(),
+        "Script not found at path: {}",
+        script_path.display()
+    );
+
+    // Workspace root: .../cdk
+    let workspace_root = crate_dir
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .expect("Failed to resolve workspace root (expected two parents)");
+
+    // Run the script via bash; success if exit status is ok
+    let output = Command::new("bash")
+        .arg(script_path.as_os_str())
+        .env("INTEGRATION_TEST", "true")
+        .current_dir(&workspace_root)
+        .output()
+        .expect("Failed to spawn bash for cairo-cli test flow");
+
+    if !output.status.success() {
+        eprintln!(
+            "cairo-cli-test-flow.sh failed with status: {}",
+            output.status
+        );
+        eprintln!(
+            "--- STDOUT ---\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        eprintln!(
+            "--- STDERR ---\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    assert!(
+        output.status.success(),
+        "cairo-cli-test-flow.sh did not complete successfully"
+    );
+}

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -14,8 +14,8 @@ use cashu::amount::SplitTarget;
 use cashu::dhke::construct_proofs;
 use cashu::mint_url::MintUrl;
 use cashu::{
-    CurrencyUnit, Id, MeltRequest, NotificationPayload, NutXXConditions, PreMintSecrets,
-    ProofState, SecretKey, SpendingConditions, State, SwapRequest,
+    CairoWitness, CurrencyUnit, Id, MeltRequest, NotificationPayload, NutXXConditions,
+    PreMintSecrets, ProofState, SecretKey, SpendingConditions, State, SwapRequest,
 };
 use cdk::mint::Mint;
 use cdk::nuts::nut00::ProofsMethods;
@@ -651,7 +651,12 @@ pub async fn test_cairo_swap() {
     let cairo_proof: String =
         include_str!("../../cashu/src/nuts/nutxx/test/is_prime_proof_7.json").to_string();
     for proof in &mut proofs {
-        proof.add_cairo_proof(cairo_proof.clone());
+        let witness = CairoWitness {
+            cairo_proof_json: cairo_proof.clone(),
+            with_pedersen: false,
+            with_bootloader: false,
+        };
+        proof.add_cairo_witness(witness);
     }
 
     let swap_request = SwapRequest::new(proofs.clone(), pre_swap.blinded_messages());

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -586,6 +586,8 @@ pub async fn test_cairo_swap() {
     let output_condition = vec![Felt::from(1)]; // program output: true
     let desired_program_output_hash = Some(NutXXConditions {
         output: Some(hash_array_felt(&output_condition)),
+        with_pedersen: Some(false), // TODO: add option as argument in CLI
+        with_bootloader: Some(false), // Currently unsupported by the wallet
     });
 
     let spending_conditions =

--- a/crates/cdk-integration-tests/tests/integration_tests_pure.rs
+++ b/crates/cdk-integration-tests/tests/integration_tests_pure.rs
@@ -586,8 +586,6 @@ pub async fn test_cairo_swap() {
     let output_condition = vec![Felt::from(1)]; // program output: true
     let desired_program_output_hash = Some(NutXXConditions {
         output: Some(hash_array_felt(&output_condition)),
-        with_pedersen: Some(false), // TODO: add option as argument in CLI
-        with_bootloader: Some(false), // Currently unsupported by the wallet
     });
 
     let spending_conditions =

--- a/crates/cdk-integration-tests/tests/scripts/cairo-cli-test-flow.sh
+++ b/crates/cdk-integration-tests/tests/scripts/cairo-cli-test-flow.sh
@@ -157,6 +157,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# ---------- Build cdk-cli (release) ----------
+need cargo
+info "Building cdk-cli (release)..."
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if ! ( cd "$REPO_ROOT" && cargo build --release -p cdk-cli ); then
+  die "Failed to build cdk-cli"
+fi
+# Point CLI to the freshly built binary if default or missing
+if [[ "$CLI" == "./target/release/cdk-cli" || ! -x "$CLI" ]]; then
+  CLI="$REPO_ROOT/target/release/cdk-cli"
+fi
+
 # ---------- Welcome & Setup ----------
 echo "Cairo CLI Integration Test"
 echo "Testing Cairo proof functionality in CDK CLI"

--- a/crates/cdk-integration-tests/tests/scripts/cairo-cli-test-flow.sh
+++ b/crates/cdk-integration-tests/tests/scripts/cairo-cli-test-flow.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# ---------- Defaults ----------
+MINT_URL="${MINT_URL:-http://localhost:8085}"
+CAIRO_EXECUTABLE_PATH="${CAIRO_EXECUTABLE_PATH:-crates/cashu/src/nuts/nutxx/test/is_prime_executable.json}"
+AMOUNT_MINT="${AMOUNT_MINT:-1000}"
+AMOUNT_TOKEN="${AMOUNT_TOKEN:-200}"
+CLI="${CLI:-./target/release/cdk-cli}"
+POLL_TIMEOUT_SEC="${POLL_TIMEOUT_SEC:-60}"
+
+# Colors (disabled if NO_COLOR is set or not a TTY)
+if [[ -z "${NO_COLOR:-}" ]] && [[ -t 1 ]]; then
+  readonly RED='\033[0;31m'
+  readonly GREEN='\033[0;32m'
+  readonly YELLOW='\033[0;33m'
+  readonly BLUE='\033[0;34m'
+  readonly WHITE='\033[1;37m'
+  readonly GRAY='\033[0;90m'
+  readonly BOLD='\033[1m'
+  readonly DIM='\033[2m'
+  readonly RESET='\033[0m'
+else
+  readonly RED='' GREEN='' YELLOW='' BLUE='' WHITE='' GRAY='' BOLD='' DIM='' RESET=''
+fi
+
+usage() {
+  cat <<EOF
+Cairo CLI Integration Test
+
+Usage: $0 [URL] [options]
+
+Positional:
+  URL                         Mint URL (e.g. http://localhost:8085)
+
+Options:
+  -m, --mint URL              Mint URL (overrides positional)
+      --amount-mint N         Amount to mint (sats)      [default: $AMOUNT_MINT]
+      --amount-token N        Amount to send/receive     [default: $AMOUNT_TOKEN]
+      --cli PATH              Path to cdk-cli binary     [default: $CLI]
+      --cairo PATH            Path to Cairo JSON         [default: $CAIRO_EXECUTABLE_PATH]
+  -h, --help                  Show this help
+
+Examples:
+  $0
+  $0 http://localhost:8085
+  $0 --amount-mint 2000 --amount-token 500
+EOF
+}
+
+# ---------- Args ----------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    -m|--mint) MINT_URL="$2"; shift 2 ;;
+    --amount-mint) AMOUNT_MINT="$2"; shift 2 ;;
+    --amount-token) AMOUNT_TOKEN="$2"; shift 2 ;;
+    --cli) CLI="$2"; shift 2 ;;
+    --cairo|--cairo-executable) CAIRO_EXECUTABLE_PATH="$2"; shift 2 ;;
+    http*://*) MINT_URL="$1"; shift ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+#----------- Exit early if Integration test ------------
+if [[ "${CI:-}" == "true" || "${INTEGRATION_TEST:-}" == "true" ]]; then
+  set -e  # Exit on any error in test mode
+fi
+
+# ---------- Nix wrap ----------
+if [[ -z "${IN_NIX_SHELL:-}" ]] && command -v nix >/dev/null 2>&1; then
+  echo "Entering nix shell..."
+  exec nix develop -c "$0" "$@"
+fi
+
+# ---------- Utils ----------
+log() {
+  printf "${GRAY}[%s]${RESET} %s\n" "$(date '+%H:%M:%S')" "$*"
+}
+
+success() {
+  printf "${GREEN}[OK]${RESET} %s\n" "$*"
+}
+
+error() {
+  printf "${RED}[ERROR]${RESET} %s\n" "$*"
+}
+
+info() {
+  printf "${BLUE}[INFO]${RESET} %s\n" "$*"
+}
+
+warn() {
+  printf "${YELLOW}[WARN]${RESET} %s\n" "$*"
+}
+
+progress() {
+  printf "${GRAY}[WAIT]${RESET} %s\n" "$*"
+}
+
+die() {
+  error "$*"
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+into() {
+  while IFS= read -r line; do
+    printf "    ${DIM}%s${RESET}\n" "$line"
+  done
+}
+
+extract_token() {
+  awk '/^cashu/{print; exit}'
+}
+
+received_amount() {
+  sed -n 's/^Received:[[:space:]]*//p' | tr -d '\r' | sed 's/[[:space:]]*$//'
+}
+
+pay_invoice_non_interactive() {
+  local inv="$1"
+  if command -v script >/dev/null 2>&1; then
+    case "$(uname -s)" in
+      Darwin) script -q /dev/null bash -lc "yes yes | just ln-lnd1 payinvoice \"$inv\"" ;;
+      Linux)  script -qfc "yes yes | just ln-lnd1 payinvoice \"$inv\"" /dev/null ;;
+      *)      script -q /dev/null sh  -c  "yes yes | just ln-lnd1 payinvoice \"$inv\"" ;;
+    esac
+  else
+    yes yes | just ln-lnd1 payinvoice "$inv"
+  fi
+}
+
+section() {
+  echo
+  printf "${BOLD}%s${RESET}\n" "$*"
+  printf "${GRAY}%s${RESET}\n" "------------------------------------------------------------"
+  echo
+}
+
+test_header() {
+  local test_num="$1"
+  local test_name="$2"
+  echo
+  printf "${BOLD}Test %s: %s${RESET}\n" "$test_num" "$test_name"
+  printf "${GRAY}%s${RESET}\n" "------------------------------------------------------------"
+}
+
+# Cleanup background jobs if we exit early
+mint_pid="" pay_pid=""
+cleanup() {
+  [[ -n "$mint_pid" ]] && kill "$mint_pid" 2>/dev/null || true
+  [[ -n "$pay_pid"  ]] && kill "$pay_pid"  2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ---------- Welcome & Setup ----------
+echo "Cairo CLI Integration Test"
+echo "Testing Cairo proof functionality in CDK CLI"
+echo
+
+# ---------- Preconditions ----------
+info "Checking prerequisites..."
+need awk; need sed; need just; need tee; need grep; need mktemp
+[[ -x "$CLI" ]] || die "Binary not found at $CLI"
+
+echo
+printf "${BOLD}Configuration:${RESET}\n"
+printf "  Mint URL:      %s\n" "$MINT_URL"
+printf "  CLI Binary:    %s\n" "$CLI"
+printf "  Cairo JSON:    %s\n" "$CAIRO_EXECUTABLE_PATH"
+printf "  Mint Amount:   %s sats\n" "$AMOUNT_MINT"
+printf "  Token Amount:  %s sats\n" "$AMOUNT_TOKEN"
+
+# ---------- 1) Mint & pay (concurrent) ----------
+section "Minting $AMOUNT_MINT sats and paying invoice"
+
+progress "Creating mint quote..."
+mint_log="$(mktemp)"
+( "$CLI" mint "$MINT_URL" "$AMOUNT_MINT" 2>&1 | tee "$mint_log" ) &
+mint_pid=$!
+
+progress "Waiting for invoice..."
+invoice=""
+spinner_chars='|/-\'
+for i in {1..300}; do
+  if line="$(grep -m1 '^Please pay: ' "$mint_log" 2>/dev/null || true)"; then
+    invoice="${line#Please pay: }"
+    [[ -n "$invoice" ]] && break
+  fi
+  if [[ $((i % 5)) -eq 0 ]]; then
+    char_idx=$(( (i / 5) % 4 ))
+    printf "\r[WAIT] Waiting for invoice... (%s/300) %s" "$i" "${spinner_chars:$char_idx:1}"
+  fi
+  sleep 0.2
+done
+printf "\r%*s\r" 80 ""  # clear line
+
+if [[ -n "$invoice" ]]; then
+  success "Invoice received"
+else
+  kill "$mint_pid" 2>/dev/null || true
+  die "Mint didn't generate an invoice"
+fi
+
+progress "Paying invoice automatically..."
+pay_invoice_non_interactive "$invoice" >/dev/null 2>&1 & pay_pid=$!
+
+progress "Waiting for mint completion..."
+if wait "$mint_pid"; then
+  success "Mint successful"
+else
+  die "Mint command failed"
+fi
+
+if wait "$pay_pid"; then
+  success "Payment completed"
+else
+  warn "Payment process finished with warnings (this may be normal)"
+fi
+
+# ---------- 2) Test 1: Happy path ----------
+test_header "1" "Cairo send + receive with prime proof (11)"
+
+progress "Creating Cairo token with spending condition..."
+SEND_OUT="$(printf "0\n%s\n" "$AMOUNT_TOKEN" | "$CLI" send \
+  --cairo-executable "$CAIRO_EXECUTABLE_PATH" \
+  --cairo-executable 1 \
+  --cairo-executable 1 2>&1)" || die "Cairo send failed"
+
+printf '%s\n' "$SEND_OUT" | into
+
+TOKEN="$(printf '%s\n' "$SEND_OUT" | extract_token)"
+[[ -n "$TOKEN" ]] || die "Failed to extract token from send output"
+
+info "Token created successfully"
+progress "Attempting to receive with prime proof (input: 11)..."
+
+set +e
+RECV_OUT="$("$CLI" receive --cairo "$CAIRO_EXECUTABLE_PATH" 1 11 -- "$TOKEN" 2>&1)"
+RECV_CODE=$?
+set -e
+
+printf '%s\n' "$RECV_OUT" | into
+
+AMT="$(printf '%s\n' "$RECV_OUT" | received_amount)"
+if [[ $RECV_CODE -eq 0 && "${AMT:-0}" -eq "$AMOUNT_TOKEN" ]]; then
+  success "Test 1 passed - received ${AMT} sats with prime proof"
+else
+  die "Test 1 failed - expected ${AMOUNT_TOKEN} sats (exit=$RECV_CODE, received=${AMT:-<none>})"
+fi
+
+# ---------- 3) Test 2: Non-prime should be rejected ----------
+test_header "2" "Cairo receive with non-prime input (9) should fail"
+
+progress "Creating another Cairo token..."
+SEND_OUT_NP="$(printf "0\n%s\n" "$AMOUNT_TOKEN" | "$CLI" send \
+  --cairo-executable "$CAIRO_EXECUTABLE_PATH" \
+  --cairo-executable 1 \
+  --cairo-executable 1 2>&1)" || die "Cairo send (non-prime test) failed"
+
+printf '%s\n' "$SEND_OUT_NP" | into
+
+TOKEN_NP="$(printf '%s\n' "$SEND_OUT_NP" | extract_token)"
+[[ -n "$TOKEN_NP" ]] || die "Failed to extract token (non-prime test)"
+
+info "Token created successfully"
+progress "Attempting to receive with non-prime proof (input: 9)..."
+
+set +e
+RECV_OUT_NP="$("$CLI" receive --cairo "$CAIRO_EXECUTABLE_PATH" 1 9 -- "$TOKEN_NP" 2>&1)"
+RECV_CODE_NP=$?
+set -e
+
+printf '%s\n' "$RECV_OUT_NP" | into
+
+AMT_NP="$(printf '%s\n' "$RECV_OUT_NP" | received_amount 2>/dev/null || true)"
+if [[ $RECV_CODE_NP -eq 0 && -n "$AMT_NP" ]]; then
+  die "Test 2 failed - expected rejection for non-prime 9, but received ${AMT_NP} sats"
+else
+  success "Test 2 passed - correctly rejected non-prime input"
+fi
+
+trap - EXIT
+
+# ---------- Final Results ----------
+echo
+printf "${BOLD}All tests passed successfully.${RESET}\n"
+printf "${DIM}Completed at %s${RESET}\n" "$(date)"
+
+if [[ "${CI:-}" == "true" || "${INTEGRATION_TEST:-}" == "true" ]]; then
+  echo "Integration test completed successfully"
+  exit 0
+fi

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -102,8 +102,6 @@ reserve_fee_min = 4
 [nutxx.cairo_prover_config]
 # Version of the `stwo_cairo_prover` dependency used
 version = "0.1.1"
-# Hasher used by the prover
-merkle_hasher = "blake2s"
 
 [nutxx.optional_features.bootloader]
 # Advertise bootloader feature (defaults to false if omitted)

--- a/crates/cdk-mintd/example.config.toml
+++ b/crates/cdk-mintd/example.config.toml
@@ -93,3 +93,20 @@ reserve_fee_min = 4
 # enabled_check_melt_quote=true
 # enabled_restore=true
 # enabled_check_proof_state=true
+
+
+[nutxx]
+# If omitted or true, NUT-XX is advertised. Set to false to disable.
+# enabled = true
+
+[nutxx.cairo_prover_config]
+# Version of the `stwo_cairo_prover` dependency used
+version = "0.1.1"
+# Hasher used by the prover
+merkle_hasher = "blake2s"
+
+[nutxx.optional_features.bootloader]
+# Advertise bootloader feature (defaults to false if omitted)
+# supported = false
+# version = "0.14.0"
+# hash = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"

--- a/crates/cdk-mintd/src/config.rs
+++ b/crates/cdk-mintd/src/config.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use bitcoin::hashes::{sha256, Hash};
+use cdk::nuts::nutxx::NutXXSettings;
 use cdk::nuts::{CurrencyUnit, PublicKey};
 use cdk::Amount;
 use cdk_axum::cache;
@@ -251,6 +252,7 @@ pub struct Settings {
     #[cfg(feature = "management-rpc")]
     pub mint_management_rpc: Option<MintManagementRpc>,
     pub auth: Option<Auth>,
+    pub nutxx: Option<NutXXSettings>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]


### PR DESCRIPTION
### Description
- Complete implementation of the cairo spending conditions for the CLI wallet:
    1. Integration of the stwo-cairo prover for swapping token with cairo spending conditions from an `executable.json`: check `cargo run --release  --bin cdk-cli receive --help` 
    3. Enabling senders to set arbitrary cairo spending conditions from an `executable.json`   or directly from the program hash: check `cargo run --release  --bin cdk-cli send --help`
    5. Integration Tests for the above

- Implementation of the `nutxx` field for the Mint Info as specified in [nutxx.md
](https://github.com/clealabs/nuts/blob/milestone1/xx.md)
    1. Versions for the prover, and the optional bootloader must be specified in [`example.toml`](https://github.com/clealabs/cdk/blob/cairo-cdk-cli/crates/cdk-mintd/example.config.toml)  

### Running the tests
1. run the mint on localhost:8085 `just regtest`
3. without stdout : `cargo test --test cairo-cli` 
4. or with stdout: `./crates/cdk-integration-tests/tests/scripts/cairo-cli-test-flow.sh`

### Notes to the reviewers
- We had to increase the request body limit of the mint server from the `2MB` default `BodySizeLimit` of the axum server to `64MB` in order to handle cairo proofs passed as witnesses.
